### PR TITLE
Surface reconstruction and Slam server

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,674 +1,201 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
-
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
-
-                            Preamble
-
-  The GNU General Public License is a free, copyleft license for
-software and other kinds of works.
-
-  The licenses for most software and other practical works are designed
-to take away your freedom to share and change the works.  By contrast,
-the GNU General Public License is intended to guarantee your freedom to
-share and change all versions of a program--to make sure it remains free
-software for all its users.  We, the Free Software Foundation, use the
-GNU General Public License for most of our software; it applies also to
-any other work released this way by its authors.  You can apply it to
-your programs, too.
-
-  When we speak of free software, we are referring to freedom, not
-price.  Our General Public Licenses are designed to make sure that you
-have the freedom to distribute copies of free software (and charge for
-them if you wish), that you receive source code or can get it if you
-want it, that you can change the software or use pieces of it in new
-free programs, and that you know you can do these things.
-
-  To protect your rights, we need to prevent others from denying you
-these rights or asking you to surrender the rights.  Therefore, you have
-certain responsibilities if you distribute copies of the software, or if
-you modify it: responsibilities to respect the freedom of others.
-
-  For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must pass on to the recipients the same
-freedoms that you received.  You must make sure that they, too, receive
-or can get the source code.  And you must show them these terms so they
-know their rights.
-
-  Developers that use the GNU GPL protect your rights with two steps:
-(1) assert copyright on the software, and (2) offer you this License
-giving you legal permission to copy, distribute and/or modify it.
-
-  For the developers' and authors' protection, the GPL clearly explains
-that there is no warranty for this free software.  For both users' and
-authors' sake, the GPL requires that modified versions be marked as
-changed, so that their problems will not be attributed erroneously to
-authors of previous versions.
-
-  Some devices are designed to deny users access to install or run
-modified versions of the software inside them, although the manufacturer
-can do so.  This is fundamentally incompatible with the aim of
-protecting users' freedom to change the software.  The systematic
-pattern of such abuse occurs in the area of products for individuals to
-use, which is precisely where it is most unacceptable.  Therefore, we
-have designed this version of the GPL to prohibit the practice for those
-products.  If such problems arise substantially in other domains, we
-stand ready to extend this provision to those domains in future versions
-of the GPL, as needed to protect the freedom of users.
-
-  Finally, every program is threatened constantly by software patents.
-States should not allow patents to restrict development and use of
-software on general-purpose computers, but in those that do, we wish to
-avoid the special danger that patents applied to a free program could
-make it effectively proprietary.  To prevent this, the GPL assures that
-patents cannot be used to render the program non-free.
-
-  The precise terms and conditions for copying, distribution and
-modification follow.
-
-                       TERMS AND CONDITIONS
-
-  0. Definitions.
-
-  "This License" refers to version 3 of the GNU General Public License.
-
-  "Copyright" also means copyright-like laws that apply to other kinds of
-works, such as semiconductor masks.
-
-  "The Program" refers to any copyrightable work licensed under this
-License.  Each licensee is addressed as "you".  "Licensees" and
-"recipients" may be individuals or organizations.
-
-  To "modify" a work means to copy from or adapt all or part of the work
-in a fashion requiring copyright permission, other than the making of an
-exact copy.  The resulting work is called a "modified version" of the
-earlier work or a work "based on" the earlier work.
-
-  A "covered work" means either the unmodified Program or a work based
-on the Program.
-
-  To "propagate" a work means to do anything with it that, without
-permission, would make you directly or secondarily liable for
-infringement under applicable copyright law, except executing it on a
-computer or modifying a private copy.  Propagation includes copying,
-distribution (with or without modification), making available to the
-public, and in some countries other activities as well.
-
-  To "convey" a work means any kind of propagation that enables other
-parties to make or receive copies.  Mere interaction with a user through
-a computer network, with no transfer of a copy, is not conveying.
-
-  An interactive user interface displays "Appropriate Legal Notices"
-to the extent that it includes a convenient and prominently visible
-feature that (1) displays an appropriate copyright notice, and (2)
-tells the user that there is no warranty for the work (except to the
-extent that warranties are provided), that licensees may convey the
-work under this License, and how to view a copy of this License.  If
-the interface presents a list of user commands or options, such as a
-menu, a prominent item in the list meets this criterion.
-
-  1. Source Code.
-
-  The "source code" for a work means the preferred form of the work
-for making modifications to it.  "Object code" means any non-source
-form of a work.
-
-  A "Standard Interface" means an interface that either is an official
-standard defined by a recognized standards body, or, in the case of
-interfaces specified for a particular programming language, one that
-is widely used among developers working in that language.
-
-  The "System Libraries" of an executable work include anything, other
-than the work as a whole, that (a) is included in the normal form of
-packaging a Major Component, but which is not part of that Major
-Component, and (b) serves only to enable use of the work with that
-Major Component, or to implement a Standard Interface for which an
-implementation is available to the public in source code form.  A
-"Major Component", in this context, means a major essential component
-(kernel, window system, and so on) of the specific operating system
-(if any) on which the executable work runs, or a compiler used to
-produce the work, or an object code interpreter used to run it.
-
-  The "Corresponding Source" for a work in object code form means all
-the source code needed to generate, install, and (for an executable
-work) run the object code and to modify the work, including scripts to
-control those activities.  However, it does not include the work's
-System Libraries, or general-purpose tools or generally available free
-programs which are used unmodified in performing those activities but
-which are not part of the work.  For example, Corresponding Source
-includes interface definition files associated with source files for
-the work, and the source code for shared libraries and dynamically
-linked subprograms that the work is specifically designed to require,
-such as by intimate data communication or control flow between those
-subprograms and other parts of the work.
-
-  The Corresponding Source need not include anything that users
-can regenerate automatically from other parts of the Corresponding
-Source.
-
-  The Corresponding Source for a work in source code form is that
-same work.
-
-  2. Basic Permissions.
-
-  All rights granted under this License are granted for the term of
-copyright on the Program, and are irrevocable provided the stated
-conditions are met.  This License explicitly affirms your unlimited
-permission to run the unmodified Program.  The output from running a
-covered work is covered by this License only if the output, given its
-content, constitutes a covered work.  This License acknowledges your
-rights of fair use or other equivalent, as provided by copyright law.
-
-  You may make, run and propagate covered works that you do not
-convey, without conditions so long as your license otherwise remains
-in force.  You may convey covered works to others for the sole purpose
-of having them make modifications exclusively for you, or provide you
-with facilities for running those works, provided that you comply with
-the terms of this License in conveying all material for which you do
-not control copyright.  Those thus making or running the covered works
-for you must do so exclusively on your behalf, under your direction
-and control, on terms that prohibit them from making any copies of
-your copyrighted material outside their relationship with you.
-
-  Conveying under any other circumstances is permitted solely under
-the conditions stated below.  Sublicensing is not allowed; section 10
-makes it unnecessary.
-
-  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
-
-  No covered work shall be deemed part of an effective technological
-measure under any applicable law fulfilling obligations under article
-11 of the WIPO copyright treaty adopted on 20 December 1996, or
-similar laws prohibiting or restricting circumvention of such
-measures.
-
-  When you convey a covered work, you waive any legal power to forbid
-circumvention of technological measures to the extent such circumvention
-is effected by exercising rights under this License with respect to
-the covered work, and you disclaim any intention to limit operation or
-modification of the work as a means of enforcing, against the work's
-users, your or third parties' legal rights to forbid circumvention of
-technological measures.
-
-  4. Conveying Verbatim Copies.
-
-  You may convey verbatim copies of the Program's source code as you
-receive it, in any medium, provided that you conspicuously and
-appropriately publish on each copy an appropriate copyright notice;
-keep intact all notices stating that this License and any
-non-permissive terms added in accord with section 7 apply to the code;
-keep intact all notices of the absence of any warranty; and give all
-recipients a copy of this License along with the Program.
-
-  You may charge any price or no price for each copy that you convey,
-and you may offer support or warranty protection for a fee.
-
-  5. Conveying Modified Source Versions.
-
-  You may convey a work based on the Program, or the modifications to
-produce it from the Program, in the form of source code under the
-terms of section 4, provided that you also meet all of these conditions:
-
-    a) The work must carry prominent notices stating that you modified
-    it, and giving a relevant date.
-
-    b) The work must carry prominent notices stating that it is
-    released under this License and any conditions added under section
-    7.  This requirement modifies the requirement in section 4 to
-    "keep intact all notices".
-
-    c) You must license the entire work, as a whole, under this
-    License to anyone who comes into possession of a copy.  This
-    License will therefore apply, along with any applicable section 7
-    additional terms, to the whole of the work, and all its parts,
-    regardless of how they are packaged.  This License gives no
-    permission to license the work in any other way, but it does not
-    invalidate such permission if you have separately received it.
-
-    d) If the work has interactive user interfaces, each must display
-    Appropriate Legal Notices; however, if the Program has interactive
-    interfaces that do not display Appropriate Legal Notices, your
-    work need not make them do so.
-
-  A compilation of a covered work with other separate and independent
-works, which are not by their nature extensions of the covered work,
-and which are not combined with it such as to form a larger program,
-in or on a volume of a storage or distribution medium, is called an
-"aggregate" if the compilation and its resulting copyright are not
-used to limit the access or legal rights of the compilation's users
-beyond what the individual works permit.  Inclusion of a covered work
-in an aggregate does not cause this License to apply to the other
-parts of the aggregate.
-
-  6. Conveying Non-Source Forms.
-
-  You may convey a covered work in object code form under the terms
-of sections 4 and 5, provided that you also convey the
-machine-readable Corresponding Source under the terms of this License,
-in one of these ways:
-
-    a) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by the
-    Corresponding Source fixed on a durable physical medium
-    customarily used for software interchange.
-
-    b) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by a
-    written offer, valid for at least three years and valid for as
-    long as you offer spare parts or customer support for that product
-    model, to give anyone who possesses the object code either (1) a
-    copy of the Corresponding Source for all the software in the
-    product that is covered by this License, on a durable physical
-    medium customarily used for software interchange, for a price no
-    more than your reasonable cost of physically performing this
-    conveying of source, or (2) access to copy the
-    Corresponding Source from a network server at no charge.
-
-    c) Convey individual copies of the object code with a copy of the
-    written offer to provide the Corresponding Source.  This
-    alternative is allowed only occasionally and noncommercially, and
-    only if you received the object code with such an offer, in accord
-    with subsection 6b.
-
-    d) Convey the object code by offering access from a designated
-    place (gratis or for a charge), and offer equivalent access to the
-    Corresponding Source in the same way through the same place at no
-    further charge.  You need not require recipients to copy the
-    Corresponding Source along with the object code.  If the place to
-    copy the object code is a network server, the Corresponding Source
-    may be on a different server (operated by you or a third party)
-    that supports equivalent copying facilities, provided you maintain
-    clear directions next to the object code saying where to find the
-    Corresponding Source.  Regardless of what server hosts the
-    Corresponding Source, you remain obligated to ensure that it is
-    available for as long as needed to satisfy these requirements.
-
-    e) Convey the object code using peer-to-peer transmission, provided
-    you inform other peers where the object code and Corresponding
-    Source of the work are being offered to the general public at no
-    charge under subsection 6d.
-
-  A separable portion of the object code, whose source code is excluded
-from the Corresponding Source as a System Library, need not be
-included in conveying the object code work.
-
-  A "User Product" is either (1) a "consumer product", which means any
-tangible personal property which is normally used for personal, family,
-or household purposes, or (2) anything designed or sold for incorporation
-into a dwelling.  In determining whether a product is a consumer product,
-doubtful cases shall be resolved in favor of coverage.  For a particular
-product received by a particular user, "normally used" refers to a
-typical or common use of that class of product, regardless of the status
-of the particular user or of the way in which the particular user
-actually uses, or expects or is expected to use, the product.  A product
-is a consumer product regardless of whether the product has substantial
-commercial, industrial or non-consumer uses, unless such uses represent
-the only significant mode of use of the product.
-
-  "Installation Information" for a User Product means any methods,
-procedures, authorization keys, or other information required to install
-and execute modified versions of a covered work in that User Product from
-a modified version of its Corresponding Source.  The information must
-suffice to ensure that the continued functioning of the modified object
-code is in no case prevented or interfered with solely because
-modification has been made.
-
-  If you convey an object code work under this section in, or with, or
-specifically for use in, a User Product, and the conveying occurs as
-part of a transaction in which the right of possession and use of the
-User Product is transferred to the recipient in perpetuity or for a
-fixed term (regardless of how the transaction is characterized), the
-Corresponding Source conveyed under this section must be accompanied
-by the Installation Information.  But this requirement does not apply
-if neither you nor any third party retains the ability to install
-modified object code on the User Product (for example, the work has
-been installed in ROM).
-
-  The requirement to provide Installation Information does not include a
-requirement to continue to provide support service, warranty, or updates
-for a work that has been modified or installed by the recipient, or for
-the User Product in which it has been modified or installed.  Access to a
-network may be denied when the modification itself materially and
-adversely affects the operation of the network or violates the rules and
-protocols for communication across the network.
-
-  Corresponding Source conveyed, and Installation Information provided,
-in accord with this section must be in a format that is publicly
-documented (and with an implementation available to the public in
-source code form), and must require no special password or key for
-unpacking, reading or copying.
-
-  7. Additional Terms.
-
-  "Additional permissions" are terms that supplement the terms of this
-License by making exceptions from one or more of its conditions.
-Additional permissions that are applicable to the entire Program shall
-be treated as though they were included in this License, to the extent
-that they are valid under applicable law.  If additional permissions
-apply only to part of the Program, that part may be used separately
-under those permissions, but the entire Program remains governed by
-this License without regard to the additional permissions.
-
-  When you convey a copy of a covered work, you may at your option
-remove any additional permissions from that copy, or from any part of
-it.  (Additional permissions may be written to require their own
-removal in certain cases when you modify the work.)  You may place
-additional permissions on material, added by you to a covered work,
-for which you have or can give appropriate copyright permission.
-
-  Notwithstanding any other provision of this License, for material you
-add to a covered work, you may (if authorized by the copyright holders of
-that material) supplement the terms of this License with terms:
-
-    a) Disclaiming warranty or limiting liability differently from the
-    terms of sections 15 and 16 of this License; or
-
-    b) Requiring preservation of specified reasonable legal notices or
-    author attributions in that material or in the Appropriate Legal
-    Notices displayed by works containing it; or
-
-    c) Prohibiting misrepresentation of the origin of that material, or
-    requiring that modified versions of such material be marked in
-    reasonable ways as different from the original version; or
-
-    d) Limiting the use for publicity purposes of names of licensors or
-    authors of the material; or
-
-    e) Declining to grant rights under trademark law for use of some
-    trade names, trademarks, or service marks; or
-
-    f) Requiring indemnification of licensors and authors of that
-    material by anyone who conveys the material (or modified versions of
-    it) with contractual assumptions of liability to the recipient, for
-    any liability that these contractual assumptions directly impose on
-    those licensors and authors.
-
-  All other non-permissive additional terms are considered "further
-restrictions" within the meaning of section 10.  If the Program as you
-received it, or any part of it, contains a notice stating that it is
-governed by this License along with a term that is a further
-restriction, you may remove that term.  If a license document contains
-a further restriction but permits relicensing or conveying under this
-License, you may add to a covered work material governed by the terms
-of that license document, provided that the further restriction does
-not survive such relicensing or conveying.
-
-  If you add terms to a covered work in accord with this section, you
-must place, in the relevant source files, a statement of the
-additional terms that apply to those files, or a notice indicating
-where to find the applicable terms.
-
-  Additional terms, permissive or non-permissive, may be stated in the
-form of a separately written license, or stated as exceptions;
-the above requirements apply either way.
-
-  8. Termination.
-
-  You may not propagate or modify a covered work except as expressly
-provided under this License.  Any attempt otherwise to propagate or
-modify it is void, and will automatically terminate your rights under
-this License (including any patent licenses granted under the third
-paragraph of section 11).
-
-  However, if you cease all violation of this License, then your
-license from a particular copyright holder is reinstated (a)
-provisionally, unless and until the copyright holder explicitly and
-finally terminates your license, and (b) permanently, if the copyright
-holder fails to notify you of the violation by some reasonable means
-prior to 60 days after the cessation.
-
-  Moreover, your license from a particular copyright holder is
-reinstated permanently if the copyright holder notifies you of the
-violation by some reasonable means, this is the first time you have
-received notice of violation of this License (for any work) from that
-copyright holder, and you cure the violation prior to 30 days after
-your receipt of the notice.
-
-  Termination of your rights under this section does not terminate the
-licenses of parties who have received copies or rights from you under
-this License.  If your rights have been terminated and not permanently
-reinstated, you do not qualify to receive new licenses for the same
-material under section 10.
-
-  9. Acceptance Not Required for Having Copies.
-
-  You are not required to accept this License in order to receive or
-run a copy of the Program.  Ancillary propagation of a covered work
-occurring solely as a consequence of using peer-to-peer transmission
-to receive a copy likewise does not require acceptance.  However,
-nothing other than this License grants you permission to propagate or
-modify any covered work.  These actions infringe copyright if you do
-not accept this License.  Therefore, by modifying or propagating a
-covered work, you indicate your acceptance of this License to do so.
-
-  10. Automatic Licensing of Downstream Recipients.
-
-  Each time you convey a covered work, the recipient automatically
-receives a license from the original licensors, to run, modify and
-propagate that work, subject to this License.  You are not responsible
-for enforcing compliance by third parties with this License.
-
-  An "entity transaction" is a transaction transferring control of an
-organization, or substantially all assets of one, or subdividing an
-organization, or merging organizations.  If propagation of a covered
-work results from an entity transaction, each party to that
-transaction who receives a copy of the work also receives whatever
-licenses to the work the party's predecessor in interest had or could
-give under the previous paragraph, plus a right to possession of the
-Corresponding Source of the work from the predecessor in interest, if
-the predecessor has it or can get it with reasonable efforts.
-
-  You may not impose any further restrictions on the exercise of the
-rights granted or affirmed under this License.  For example, you may
-not impose a license fee, royalty, or other charge for exercise of
-rights granted under this License, and you may not initiate litigation
-(including a cross-claim or counterclaim in a lawsuit) alleging that
-any patent claim is infringed by making, using, selling, offering for
-sale, or importing the Program or any portion of it.
-
-  11. Patents.
-
-  A "contributor" is a copyright holder who authorizes use under this
-License of the Program or a work on which the Program is based.  The
-work thus licensed is called the contributor's "contributor version".
-
-  A contributor's "essential patent claims" are all patent claims
-owned or controlled by the contributor, whether already acquired or
-hereafter acquired, that would be infringed by some manner, permitted
-by this License, of making, using, or selling its contributor version,
-but do not include claims that would be infringed only as a
-consequence of further modification of the contributor version.  For
-purposes of this definition, "control" includes the right to grant
-patent sublicenses in a manner consistent with the requirements of
-this License.
-
-  Each contributor grants you a non-exclusive, worldwide, royalty-free
-patent license under the contributor's essential patent claims, to
-make, use, sell, offer for sale, import and otherwise run, modify and
-propagate the contents of its contributor version.
-
-  In the following three paragraphs, a "patent license" is any express
-agreement or commitment, however denominated, not to enforce a patent
-(such as an express permission to practice a patent or covenant not to
-sue for patent infringement).  To "grant" such a patent license to a
-party means to make such an agreement or commitment not to enforce a
-patent against the party.
-
-  If you convey a covered work, knowingly relying on a patent license,
-and the Corresponding Source of the work is not available for anyone
-to copy, free of charge and under the terms of this License, through a
-publicly available network server or other readily accessible means,
-then you must either (1) cause the Corresponding Source to be so
-available, or (2) arrange to deprive yourself of the benefit of the
-patent license for this particular work, or (3) arrange, in a manner
-consistent with the requirements of this License, to extend the patent
-license to downstream recipients.  "Knowingly relying" means you have
-actual knowledge that, but for the patent license, your conveying the
-covered work in a country, or your recipient's use of the covered work
-in a country, would infringe one or more identifiable patents in that
-country that you have reason to believe are valid.
-
-  If, pursuant to or in connection with a single transaction or
-arrangement, you convey, or propagate by procuring conveyance of, a
-covered work, and grant a patent license to some of the parties
-receiving the covered work authorizing them to use, propagate, modify
-or convey a specific copy of the covered work, then the patent license
-you grant is automatically extended to all recipients of the covered
-work and works based on it.
-
-  A patent license is "discriminatory" if it does not include within
-the scope of its coverage, prohibits the exercise of, or is
-conditioned on the non-exercise of one or more of the rights that are
-specifically granted under this License.  You may not convey a covered
-work if you are a party to an arrangement with a third party that is
-in the business of distributing software, under which you make payment
-to the third party based on the extent of your activity of conveying
-the work, and under which the third party grants, to any of the
-parties who would receive the covered work from you, a discriminatory
-patent license (a) in connection with copies of the covered work
-conveyed by you (or copies made from those copies), or (b) primarily
-for and in connection with specific products or compilations that
-contain the covered work, unless you entered into that arrangement,
-or that patent license was granted, prior to 28 March 2007.
-
-  Nothing in this License shall be construed as excluding or limiting
-any implied license or other defenses to infringement that may
-otherwise be available to you under applicable patent law.
-
-  12. No Surrender of Others' Freedom.
-
-  If conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot convey a
-covered work so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you may
-not convey it at all.  For example, if you agree to terms that obligate you
-to collect a royalty for further conveying from those to whom you convey
-the Program, the only way you could satisfy both those terms and this
-License would be to refrain entirely from conveying the Program.
-
-  13. Use with the GNU Affero General Public License.
-
-  Notwithstanding any other provision of this License, you have
-permission to link or combine any covered work with a work licensed
-under version 3 of the GNU Affero General Public License into a single
-combined work, and to convey the resulting work.  The terms of this
-License will continue to apply to the part which is the covered work,
-but the special requirements of the GNU Affero General Public License,
-section 13, concerning interaction through a network will apply to the
-combination as such.
-
-  14. Revised Versions of this License.
-
-  The Free Software Foundation may publish revised and/or new versions of
-the GNU General Public License from time to time.  Such new versions will
-be similar in spirit to the present version, but may differ in detail to
-address new problems or concerns.
-
-  Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU General
-Public License "or any later version" applies to it, you have the
-option of following the terms and conditions either of that numbered
-version or of any later version published by the Free Software
-Foundation.  If the Program does not specify a version number of the
-GNU General Public License, you may choose any version ever published
-by the Free Software Foundation.
-
-  If the Program specifies that a proxy can decide which future
-versions of the GNU General Public License can be used, that proxy's
-public statement of acceptance of a version permanently authorizes you
-to choose that version for the Program.
-
-  Later license versions may give you additional or different
-permissions.  However, no additional obligations are imposed on any
-author or copyright holder as a result of your choosing to follow a
-later version.
-
-  15. Disclaimer of Warranty.
-
-  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
-APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
-OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
-IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
-ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-
-  16. Limitation of Liability.
-
-  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
-THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
-GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
-USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
-DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
-PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
-EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGES.
-
-  17. Interpretation of Sections 15 and 16.
-
-  If the disclaimer of warranty and limitation of liability provided
-above cannot be given local legal effect according to their terms,
-reviewing courts shall apply local law that most closely approximates
-an absolute waiver of all civil liability in connection with the
-Program, unless a warranty or assumption of liability accompanies a
-copy of the Program in return for a fee.
-
-                     END OF TERMS AND CONDITIONS
-
-            How to Apply These Terms to Your New Programs
-
-  If you develop a new program, and you want it to be of the greatest
-possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.
-
-  To do so, attach the following notices to the program.  It is safest
-to attach them to the start of each source file to most effectively
-state the exclusion of warranty; and each file should have at least
-the "copyright" line and a pointer to where the full notice is found.
-
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-Also add information on how to contact you by electronic and paper mail.
-
-  If the program does terminal interaction, make it output a short
-notice like this when it starts in an interactive mode:
-
-    <program>  Copyright (C) <year>  <name of author>
-    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, your program's commands
-might be different; for a GUI interface, you would use an "about box".
-
-  You should also get your employer (if you work as a programmer) or school,
-if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL, see
-<https://www.gnu.org/licenses/>.
-
-  The GNU General Public License does not permit incorporating your program
-into proprietary programs.  If your program is a subroutine library, you
-may consider it more useful to permit linking proprietary applications with
-the library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.  But first, please read
-<https://www.gnu.org/licenses/why-not-lgpl.html>.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ ament_lint_auto
 
 ## 📜 License
 
-This project is licensed under the **GNU General Public License v3.0 (GPL-3.0)**.  
+This project is licensed under the **Apache 2 License**.  
 See the [LICENSE](LICENSE) file for details.
 
 ---

--- a/navmap_core/include/navmap_core/Geometry.hpp
+++ b/navmap_core/include/navmap_core/Geometry.hpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 /**
  * @file Geometry.hpp

--- a/navmap_core/package.xml
+++ b/navmap_core/package.xml
@@ -5,7 +5,8 @@
   <version>0.0.1</version>
   <description>Core C++ library for NavMap.</description>
   <maintainer email="fmrico@gmail.com">Francisco Martín Rico</maintainer>
-  <license>GPL-3.0-or-later</license>
+
+  <license>Apache License, Version 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/navmap_core/src/navmap_core/NavMap.cpp
+++ b/navmap_core/src/navmap_core/NavMap.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #include "navmap_core/NavMap.hpp"

--- a/navmap_core/tests/test_geometry.cpp
+++ b/navmap_core/tests/test_geometry.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <gtest/gtest.h>
 #include <Eigen/Core>

--- a/navmap_core/tests/test_locate_grid.cpp
+++ b/navmap_core/tests/test_locate_grid.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <gtest/gtest.h>
 #include "navmap_core/NavMap.hpp"

--- a/navmap_core/tests/test_navmap.cpp
+++ b/navmap_core/tests/test_navmap.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <gtest/gtest.h>
 #include <Eigen/Core>

--- a/navmap_core/tests/test_navmap_easy.cpp
+++ b/navmap_core/tests/test_navmap_easy.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <gtest/gtest.h>
 #include <Eigen/Core>

--- a/navmap_core/tests/test_navmap_uniform_and_closest.cpp
+++ b/navmap_core/tests/test_navmap_uniform_and_closest.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <gtest/gtest.h>
 #include <Eigen/Core>

--- a/navmap_core/tests/test_raycast_many.cpp
+++ b/navmap_core/tests/test_raycast_many.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <gtest/gtest.h>
 #include "navmap_core/NavMap.hpp"

--- a/navmap_examples/package.xml
+++ b/navmap_examples/package.xml
@@ -5,7 +5,8 @@
   <version>0.1.0</version>
   <description>Examples related to navmap_core y navmap_ros.</description>
   <maintainer email="fmrico@gmail.com">fmrico</maintainer>
-  <license>MIT</license>
+
+  <license>Apache License, Version 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/navmap_examples/src/01_flat_plane.cpp
+++ b/navmap_examples/src/01_flat_plane.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #include <iostream>

--- a/navmap_examples/src/02_two_floors.cpp
+++ b/navmap_examples/src/02_two_floors.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #include <iostream>

--- a/navmap_examples/src/03_slope_surface.cpp
+++ b/navmap_examples/src/03_slope_surface.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #include <iostream>

--- a/navmap_examples/src/04_layers.cpp
+++ b/navmap_examples/src/04_layers.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #include <iostream>

--- a/navmap_examples/src/05_neighbors_and_centroids.cpp
+++ b/navmap_examples/src/05_neighbors_and_centroids.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #include <iostream>

--- a/navmap_examples/src/06_area_marking.cpp
+++ b/navmap_examples/src/06_area_marking.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #include <iostream>

--- a/navmap_examples/src/07_raycast.cpp
+++ b/navmap_examples/src/07_raycast.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #include <iostream>

--- a/navmap_examples/src/08_copy_and_assign.cpp
+++ b/navmap_examples/src/08_copy_and_assign.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #include <iostream>

--- a/navmap_examples/src_ros2/01_from_occgrid.cpp
+++ b/navmap_examples/src_ros2/01_from_occgrid.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #include <rclcpp/rclcpp.hpp>

--- a/navmap_examples/src_ros2/02_to_occgrid.cpp
+++ b/navmap_examples/src_ros2/02_to_occgrid.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #include <rclcpp/rclcpp.hpp>

--- a/navmap_examples/src_ros2/03_save_load.cpp
+++ b/navmap_examples/src_ros2/03_save_load.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 // Guardar/cargar NavMap en JSON muy simple (demo) — geometría + una capa U8

--- a/navmap_ros/CMakeLists.txt
+++ b/navmap_ros/CMakeLists.txt
@@ -15,7 +15,9 @@ find_package(navmap_ros_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(PCL REQUIRED COMPONENTS common io)
+find_package(std_srvs REQUIRED)
+find_package(PCL REQUIRED COMPONENTS common io kdtree search)
+find_package(pcl_conversions REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
   src/${PROJECT_NAME}/conversions.cpp
@@ -29,13 +31,19 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 target_link_libraries(${PROJECT_NAME} PUBLIC
   rclcpp::rclcpp
   navmap_core::navmap_core
+  pcl_conversions::pcl_conversions
   ${navmap_ros_interfaces_TARGETS}
   ${geometry_msgs_TARGETS}
   ${nav_msgs_TARGETS}
   ${sensor_msgs_TARGETS}
+  ${std_srvs_TARGETS}
   ${PCL_LIBRARIES}
 )
 
+add_executable(slam_server_app
+  src/slam_server_app.cpp
+)
+target_link_libraries(slam_server_app ${PROJECT_NAME})
 
 install(
   DIRECTORY include/
@@ -44,6 +52,7 @@ install(
 
 install(TARGETS
   ${PROJECT_NAME}
+  slam_server_app
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -71,5 +80,6 @@ ament_export_dependencies(
   geometry_msgs
   sensor_msgs
   PCL
+  pcl_conversions
 )
 ament_package()

--- a/navmap_ros/include/navmap_ros/conversions.hpp
+++ b/navmap_ros/include/navmap_ros/conversions.hpp
@@ -163,12 +163,12 @@ struct BuildParams
   Eigen::Vector3f seed = {0.0, 0.0, 0.0};
   float resolution = 1.0;
   float max_edge_len = 2.0;
-  float max_slope_deg = 30.0f;   // pendiente máxima respecto a vertical
-  float neighbor_radius = 2.0f;  // radio de búsqueda
-  int   k_neighbors = 20;        // si prefieres k-NN en vez de radio
-  float min_area = 1e-6f;        // área mínima para evitar degenerados
+  float max_slope_deg = 30.0f;   // maximum slope w.r.t. vertical
+  float neighbor_radius = 2.0f;  // search radius
+  int   k_neighbors = 20;        // k-NN alternative to radius
+  float min_area = 1e-6f;        // minimum triangle area to avoid degenerates
   bool  use_radius = true;
-  float min_angle_deg = 20.0f;   // grados -> evita triángulos muy agudos (slivers)
+  float min_angle_deg = 20.0f;   // minimum interior angle (deg) to avoid sliver triangles
 };
 
 navmap::NavMap from_pointcloud2(

--- a/navmap_ros/include/navmap_ros/conversions.hpp
+++ b/navmap_ros/include/navmap_ros/conversions.hpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #ifndef NAVMAP_ROS__CONVERSIONS_HPP_

--- a/navmap_ros/include/navmap_ros/conversions.hpp
+++ b/navmap_ros/include/navmap_ros/conversions.hpp
@@ -43,10 +43,12 @@
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
-#include <navmap_ros_interfaces/msg/nav_map.hpp>
-#include <nav_msgs/msg/occupancy_grid.hpp>
-#include <navmap_core/NavMap.hpp>
-#include <navmap_ros_interfaces/msg/nav_map.hpp>
+#include "sensor_msgs/msg/point_cloud2.hpp"
+#include "navmap_ros_interfaces/msg/nav_map.hpp"
+#include "navmap_ros_interfaces/msg/nav_map_layer.hpp"
+#include "nav_msgs/msg/occupancy_grid.hpp"
+
+#include "navmap_core/NavMap.hpp"
 
 /**
  * @namespace navmap_ros
@@ -156,42 +158,23 @@ navmap::NavMap from_occupancy_grid(const nav_msgs::msg::OccupancyGrid & grid);
  */
 nav_msgs::msg::OccupancyGrid to_occupancy_grid(const navmap::NavMap & nm);
 
-/**
- * @brief Serialize a triangle mesh (from a PCL point cloud and index triplets) into
- *        a `navmap_ros_interfaces::msg::NavMap`, optionally returning the core `navmap::NavMap`.
- *
- * This function is useful to publish arbitrary triangle surfaces through ROS without having to
- * manually assemble the transport message. The input mesh is assumed to be watertight or at
- * least manifold enough for downstream consumers; no global repair is performed.
- *
- * @param[in] cloud      Vertex positions as a PCL point cloud. Only XYZ is used.
- * @param[in] triangles  Triangle index triplets (each `Eigen::Vector3i` stores indices into @p cloud).
- * @param[in] frame_id   TF frame id to assign to the resulting surface.
- * @param[out] out_msg   Output transport message containing geometry, one surface, and no layers.
- * @param[out] out_core_opt Optional pointer to receive the constructed core `navmap::NavMap`.
- *                          If non-null, a copy of the internal core representation is written here.
- *
- * @return `true` on success, `false` if inputs are inconsistent (e.g., out-of-range indices,
- *         NaN/Inf coordinates) and the message cannot be built.
- *
- * @post
- *  - `out_msg` contains:
- *      * All input vertices in order.
- *      * All input triangles (winding preserved as provided).
- *      * A single surface with `frame_id` set to @p frame_id and containing all triangles.
- *  - If @p out_core_opt is provided, it mirrors the same content for direct core-level use.
- *
- * @warning This function does not compute or attach per-NavCel layers. If you need layers
- *          (e.g., `"elevation"`, `"occupancy"`), create and populate them explicitly afterward.
- * @warning Triangle normals and adjacency are computed by the core upon `rebuild_geometry_accels()`.
- *          If you plan to query topology or do ray casts, call that method on the core map you use.
- */
-bool build_navmap_from_mesh(
-  const pcl::PointCloud<pcl::PointXYZ> & cloud,
-  const std::vector<Eigen::Vector3i> & triangles,
-  const std::string & frame_id,
+struct BuildParams
+{
+  Eigen::Vector3f seed = {0.0, 0.0, 0.0};
+  float resolution = 1.0;
+  float max_edge_len = 2.0;
+  float max_slope_deg = 30.0f;   // pendiente máxima respecto a vertical
+  float neighbor_radius = 2.0f;  // radio de búsqueda
+  int   k_neighbors = 20;        // si prefieres k-NN en vez de radio
+  float min_area = 1e-6f;        // área mínima para evitar degenerados
+  bool  use_radius = true;
+  float min_angle_deg = 20.0f;   // grados -> evita triángulos muy agudos (slivers)
+};
+
+navmap::NavMap from_pointcloud2(
+  const sensor_msgs::msg::PointCloud2 & pc2,
   navmap_ros_interfaces::msg::NavMap & out_msg,
-  navmap::NavMap * out_core_opt = nullptr);
+  BuildParams params);
 
 }  // namespace navmap_ros
 

--- a/navmap_ros/include/navmap_ros/navmap_io.hpp
+++ b/navmap_ros/include/navmap_ros/navmap_io.hpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #ifndef NAVMAP_ROS__NAVMAP_IO_HPP_

--- a/navmap_ros/package.xml
+++ b/navmap_ros/package.xml
@@ -4,7 +4,8 @@
   <version>0.0.1</version>
   <description>Conversions between navmap_core and ROS messages</description>
   <maintainer email="fmrico@gmail.com">Francisco Martín Rico</maintainer>
-  <license>GPLv3</license>
+
+  <license>Apache License, Version 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/navmap_ros/package.xml
+++ b/navmap_ros/package.xml
@@ -14,6 +14,7 @@
   <depend>navmap_ros_interfaces</depend>
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>
 

--- a/navmap_ros/src/navmap_ros/conversions.cpp
+++ b/navmap_ros/src/navmap_ros/conversions.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "navmap_ros/conversions.hpp"
 

--- a/navmap_ros/src/navmap_ros/conversions.cpp
+++ b/navmap_ros/src/navmap_ros/conversions.cpp
@@ -61,7 +61,7 @@ static inline int8_t u8_to_occ(uint8_t u)
   return static_cast<int8_t>(std::lround((u / 254.0) * 100.0));
 }
 
-// Given grid dims (W,H) and pattern=0, the two triangles indices for cell (i,j):
+// Given grid dims (W,H) and pattern=0, the two triangle indices for cell (i,j):
 // tri0=(i,j)->(i+1,j)->(i+1,j+1), tri1=(i,j)->(i+1,j+1)->(i,j+1)
 static inline navmap::NavCelId tri_index_for_cell(uint32_t i, uint32_t j, uint32_t W)
 {
@@ -331,7 +331,7 @@ navmap::NavMap from_occupancy_grid(const nav_msgs::msg::OccupancyGrid & grid)
   // 4) Derived geometry
   nm.rebuild_geometry_accels();
 
-  // 5) Per-NavCel layer "occupancy" (U8), two tris per cell with same value
+  // 5) Per-NavCel "occupancy" layer (U8), two triangles per cell with the same value
   auto occ = nm.layers.add_or_get<uint8_t>("occupancy", nm.navcels.size(), navmap::LayerType::U8);
   tidx = 0;
   auto cell_id = [W](uint32_t i, uint32_t j) {return j * W + i;};
@@ -366,10 +366,8 @@ nav_msgs::msg::OccupancyGrid to_occupancy_grid(const navmap::NavMap & nm)
   auto occ = std::dynamic_pointer_cast<navmap::LayerView<uint8_t>>(base);
 
   // Fast path: detect regular grid from positions and triangle layout.
-  // We infer W,H, res and origin from the surface AABB & vertex lattice.
-  // Assumptions: single flat Z plane, regular spacing in X,Y, raster tri order.
+  // Assumptions: single flat Z plane, regular spacing in X/Y, raster triangle order.
   if (nm.surfaces.size() == 1) {
-    // Heuristic: infer W,H by counting unique X and Y coordinates.
     std::vector<float> xs(nm.positions.x.begin(), nm.positions.x.end());
     std::vector<float> ys(nm.positions.y.begin(), nm.positions.y.end());
     std::sort(xs.begin(), xs.end()); xs.erase(std::unique(xs.begin(), xs.end()), xs.end());
@@ -516,7 +514,7 @@ bool build_navmap_from_mesh(
     out_msg.layers.push_back(std::move(layer));
   }
 
-  // 4) Convert a kernel if requested
+  // 4) Convert to core structure if requested
   if (out_core_opt) {
     *out_core_opt = navmap_ros::from_msg(out_msg);
   }
@@ -556,13 +554,13 @@ static inline float tri_slope_deg(
   Eigen::Vector3f n = (b - a).cross(c - a);
   float nn = n.norm();
   if (nn < 1e-9f) {return 0.0f;}
-  float cos_theta = std::abs(n.normalized().dot(Eigen::Vector3f::UnitZ())); // cos con vertical
+  float cos_theta = std::abs(n.normalized().dot(Eigen::Vector3f::UnitZ())); // cosine w.r.t. vertical
   cos_theta = std::clamp(cos_theta, 0.0f, 1.0f);
-  float theta = std::acos(cos_theta); // ángulo con vertical
+  float theta = std::acos(cos_theta); // angle w.r.t. vertical
   return theta * 180.0f / static_cast<float>(M_PI);
 }
 
-// Claves para evitar duplicados
+// Keys to avoid duplicates
 struct EdgeKey
 {
   int a, b;
@@ -608,28 +606,27 @@ static inline TriKey make_tri(int i, int j, int k)
   return {v[0], v[1], v[2]};
 }
 
-// PCA local para obtener plano tangente en v
-// Devuelve dos ejes ortogonales t1, t2 en el plano tangente.
-// Si falla PCA (muy pocos puntos), usa un par ortonormal arbitrario.
+// Local PCA to obtain a tangent plane at v.
+// Returns two orthogonal axes t1, t2 on the tangent plane.
+// If PCA is unreliable (too few points), fall back to a stable orthonormal pair.
 inline void local_tangent_basis(
   const std::vector<Eigen::Vector3f> & nbrs,
   Eigen::Vector3f & t1, Eigen::Vector3f & t2)
 {
   if (nbrs.size() < 3) {
-    // base por defecto (proyección estable)
     t1 = Eigen::Vector3f::UnitX();
     t2 = Eigen::Vector3f::UnitY();
     return;
   }
 
-  // Centra
+  // Center
   Eigen::Vector3f mean = Eigen::Vector3f::Zero();
   for (auto & p : nbrs) {
     mean += p;
   }
   mean /= static_cast<float>(nbrs.size());
 
-  // Covarianza
+  // Covariance
   Eigen::Matrix3f C = Eigen::Matrix3f::Zero();
   for (auto & p : nbrs) {
     Eigen::Vector3f d = p - mean;
@@ -637,15 +634,13 @@ inline void local_tangent_basis(
   }
   C /= static_cast<float>(nbrs.size());
 
-  // Autovectores
+  // Eigenvectors
   Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> es(C);
-  // Valores ascendentes: 0 -> menor (normal aproximada)
-  // Eigen::Vector3f e0 = es.eigenvectors().col(0); // normal aproximada
+  // Ascending eigenvalues: column 0 ~ smallest (approximate normal)
   Eigen::Vector3f e1 = es.eigenvectors().col(1);
   Eigen::Vector3f e2 = es.eigenvectors().col(2);
 
-  // Plano tangente: proyectaremos en {e1, e2}
-  // Asegura ortonormalidad y evita inversión esporádica
+  // Tangent plane basis {e1, e2}
   t1 = e1.normalized();
   t2 = (e2 - e2.dot(t1) * t1).normalized();
 }
@@ -656,18 +651,18 @@ inline void triangle_angles_deg(
   const Eigen::Vector3f & C,
   float & angA, float & angB, float & angC)
 {
-  // Lados opuestos a A, B, C
+  // Sides opposite to vertices A, B, C
   float a = (B - C).norm();
   float b = (C - A).norm();
   float c = (A - B).norm();
 
-  // Evitar divisiones por cero
+  // Avoid divisions by zero
   const float eps = 1e-12f;
   a = std::max(a, eps);
   b = std::max(b, eps);
   c = std::max(c, eps);
 
-  // Ley de cosenos con clamp numérico
+  // Law of cosines with numeric clamping
   auto angle_from = [](float opp, float x, float y) -> float {
       float cosv = (x * x + y * y - opp * opp) / (2.0f * x * y);
       cosv = std::min(1.0f, std::max(-1.0f, cosv));
@@ -679,7 +674,7 @@ inline void triangle_angles_deg(
   angC = angle_from(c, a, b);
 }
 
-// Ordena vecinos por ángulo en el plano tangente de v
+// Sort neighbors by angle on the tangent plane at v
 inline void sort_neighbors_angular(
   const Eigen::Vector3f & vpos,
   const std::vector<std::pair<int, Eigen::Vector3f>> & nbrs,  // (idx, pos)
@@ -715,7 +710,7 @@ inline void sort_neighbors_angular(
   }
 }
 
-// Intenta crear un triángulo (i,j,k) bajo las restricciones
+// Attempt to add triangle (i,j,k) under the given constraints
 inline bool try_add_triangle(
   int i, int j, int k,
   const pcl::PointCloud<pcl::PointXYZ> & cloud,
@@ -732,7 +727,7 @@ inline bool try_add_triangle(
   const auto & C = cloud[k];
   if (!pcl::isFinite(A) || !pcl::isFinite(B) || !pcl::isFinite(C)) {return false;}
 
-  // Longitudes máximas de arista
+  // Max edge length
   auto dAB = dist3(A, B);
   auto dBC = dist3(B, C);
   auto dCA = dist3(C, A);
@@ -742,14 +737,14 @@ inline bool try_add_triangle(
   Eigen::Vector3f b(B.x, B.y, B.z);
   Eigen::Vector3f c(C.x, C.y, C.z);
 
-  // Área mínima
+  // Min area
   if (tri_area(a, b, c) < P.min_area) {return false;}
 
-  // Pendiente máxima
+  // Max slope
   float slope = tri_slope_deg(a, b, c);
   if (slope > P.max_slope_deg) {return false;}
 
-  // Ángulo mínimo en los tres vértices
+  // Min angle at each vertex
   float angA, angB, angC;
   triangle_angles_deg(a, b, c, angA, angB, angC);
   if (angA < P.min_angle_deg || angB < P.min_angle_deg || angC < P.min_angle_deg) {
@@ -762,13 +757,10 @@ inline bool try_add_triangle(
     if (n.norm() < 1e-9f) {return false;}
     if (n.dot(up) < 0.0f) {
       std::swap(j, k);
-      // si más abajo usas b/c otra vez, re-asigna:
-      // b = Eigen::Vector3f(cloud[j].x, cloud[j].y, cloud[j].z);
-      // c = Eigen::Vector3f(cloud[k].x, cloud[k].y, cloud[k].z);
     }
   }
 
-  // Aceptar
+  // Accept
   tri_set.insert(tk);
   edge_set.insert(make_edge(i, j));
   edge_set.insert(make_edge(j, k));
@@ -790,7 +782,7 @@ struct VoxelHash
 {
   std::size_t operator()(const Voxel & v) const noexcept
   {
-    // Hash simple y estable
+    // Simple, stable hash
     std::size_t h = 1469598103934665603ull; // FNV-1a offset
     auto mix = [&](int k) {
         std::size_t x = static_cast<std::size_t>(k);
@@ -818,9 +810,9 @@ downsample_voxelize_avgXYZ(
   pcl::PointCloud<pcl::PointXYZ> output;
 
   std::unordered_map<Voxel, VoxelAccum, VoxelHash> voxels;
-  voxels.reserve(input_points.size() / 2); // estimación
+  voxels.reserve(input_points.size() / 2); // rough estimate
 
-  // 1) Acumular todos los puntos por voxel
+  // 1) Accumulate all points per voxel
   for (std::size_t i = 0; i < input_points.size(); ++i) {
     const auto & pt = input_points[i];
     if (!pcl::isFinite(pt)) {continue;}
@@ -837,7 +829,7 @@ downsample_voxelize_avgXYZ(
     acc.count += 1;
   }
 
-  // 2) Generar un punto promedio por voxel
+  // 2) Emit one averaged point per voxel
   output.points.reserve(voxels.size());
   for (const auto & kv : voxels) {
     const VoxelAccum & acc = kv.second;
@@ -860,7 +852,6 @@ std::vector<Triangle> grow_surface_from_seed(
   int seed_idx,
   const BuildParams & P)
 {
-  std::cerr << "1" << std::endl;
   std::vector<Triangle> tris;
   if (cloud.empty() || seed_idx < 0 || seed_idx >= static_cast<int>(cloud.size())) {
     return tris;
@@ -886,7 +877,7 @@ std::vector<Triangle> grow_surface_from_seed(
 
     if (!pcl::isFinite(V)) {continue;}
 
-    // 1) Vecindad
+    // 1) Neighborhood
     nbr_indices.clear(); nbr_dists.clear();
     int found = 0;
     if (P.use_radius) {
@@ -894,9 +885,9 @@ std::vector<Triangle> grow_surface_from_seed(
     } else {
       found = kdtree.nearestKSearch(V, P.k_neighbors, nbr_indices, nbr_dists);
     }
-    if (found <= 1) {continue;} // sólo él mismo
+    if (found <= 1) {continue;} // only itself
 
-    // 2) Filtra por arista y descarta el propio v
+    // 2) Filter by edge length and drop v itself
     std::vector<std::pair<int, Eigen::Vector3f>> candidates;
     candidates.reserve(found);
     for (int idx : nbr_indices) {
@@ -909,15 +900,14 @@ std::vector<Triangle> grow_surface_from_seed(
     }
     if (candidates.size() < 2) {continue;}
 
-    // 3) Orden angular en plano tangente local de v
+    // 3) Angular order on the local tangent plane at v
     Eigen::Vector3f vpos(V.x, V.y, V.z);
     std::vector<int> ordered;
     sort_neighbors_angular(vpos, candidates, ordered);
 
-    // 4) Intenta triángulos en abanico (pares consecutivos)
-    //    También puedes cerrar el abanico conectando último con primero si procede.
+    // 4) Try fan triangles from consecutive pairs
+    //    Optionally close the fan by connecting last with first.
     for (size_t t = 0; t + 1 < ordered.size(); ++t) {
-      // std::cerr << "t = " << t <<std::endl;
       int i = v;
       int j = ordered[t];
       int k = ordered[t + 1];
@@ -927,7 +917,7 @@ std::vector<Triangle> grow_surface_from_seed(
         if (!seen.count(k)) {frontier.push(k); seen.insert(k);}
       }
     }
-    // Cierre opcional del abanico (si quieres malla más densa):
+    // Optional fan closure
     int j0 = ordered.front(), k0 = ordered.back();
     try_add_triangle(v, k0, j0, cloud, P, tri_set, edge_set, tris);
   }

--- a/navmap_ros/src/navmap_ros/conversions.cpp
+++ b/navmap_ros/src/navmap_ros/conversions.cpp
@@ -20,12 +20,23 @@
 #include <cassert>
 #include <unordered_map>
 
-#include <geometry_msgs/msg/pose.hpp>
+#include "geometry_msgs/msg/pose.hpp"
 #include <std_msgs/msg/header.hpp>
+#include "sensor_msgs/msg/point_cloud2.hpp"
+#include "navmap_ros_interfaces/msg/nav_map.hpp"
+#include "navmap_ros_interfaces/msg/nav_map_layer.hpp"
+#include "nav_msgs/msg/occupancy_grid.hpp"
 
-#include <navmap_core/Geometry.hpp>
-#include <navmap_ros_interfaces/msg/nav_map_layer.hpp>
-#include <navmap_ros_interfaces/msg/nav_map_surface.hpp>
+#include "navmap_core/Geometry.hpp"
+
+#include "pcl_conversions/pcl_conversions.h"
+#include "pcl/point_types_conversion.h"
+
+#include "pcl/common/transforms.h"
+#include "pcl/point_cloud.h"
+#include "pcl/point_types.h"
+#include "pcl/PointIndices.h"
+#include "pcl/kdtree/kdtree_flann.h"
 
 namespace navmap_ros
 {
@@ -505,14 +516,465 @@ bool build_navmap_from_mesh(
     out_msg.layers.push_back(std::move(layer));
   }
 
-  // (Optional) Vertex colors -> out_msg.has_vertex_rgba = true; ... (r,g,b,a)
-  // (Optional) Surfaces -> you can group navcels by surface later
-
   // 4) Convert a kernel if requested
   if (out_core_opt) {
     *out_core_opt = navmap_ros::from_msg(out_msg);
   }
   return true;
 }
+
+// ----------------- Surface from PC2 -----------------
+
+
+using Triangle = Eigen::Vector3i;
+
+static inline float sqr(float v) {return v * v;}
+static inline float dist3(const pcl::PointXYZ & a, const pcl::PointXYZ & b)
+{
+  return std::sqrt(sqr(a.x - b.x) + sqr(a.y - b.y) + sqr(a.z - b.z));
+}
+
+static inline float clamp01(float x)
+{
+  if (x < 0.0f) {return 0.0f;}
+  if (x > 1.0f) {return 1.0f;}
+  return x;
+}
+
+static inline float tri_area(
+  const Eigen::Vector3f & a,
+  const Eigen::Vector3f & b,
+  const Eigen::Vector3f & c)
+{
+  return 0.5f * ((b - a).cross(c - a)).norm();
+}
+static inline float tri_slope_deg(
+  const Eigen::Vector3f & a,
+  const Eigen::Vector3f & b,
+  const Eigen::Vector3f & c)
+{
+  Eigen::Vector3f n = (b - a).cross(c - a);
+  float nn = n.norm();
+  if (nn < 1e-9f) {return 0.0f;}
+  float cos_theta = std::abs(n.normalized().dot(Eigen::Vector3f::UnitZ())); // cos con vertical
+  cos_theta = std::clamp(cos_theta, 0.0f, 1.0f);
+  float theta = std::acos(cos_theta); // ángulo con vertical
+  return theta * 180.0f / static_cast<float>(M_PI);
+}
+
+// Claves para evitar duplicados
+struct EdgeKey
+{
+  int a, b;
+  bool operator==(const EdgeKey & o) const noexcept {return a == o.a && b == o.b;}
+};
+struct EdgeHasher
+{
+  std::size_t operator()(const EdgeKey & e) const noexcept
+  {
+    return (static_cast<std::size_t>(e.a) << 32) ^ static_cast<std::size_t>(e.b);
+  }
+};
+static inline EdgeKey make_edge(int i, int j)
+{
+  if (i < j) {return {i, j};}
+  return {j, i};
+}
+
+struct TriKey
+{
+  int a, b, c;
+  bool operator==(const TriKey & o) const noexcept
+  {
+    return a == o.a && b == o.b && c == o.c;
+  }
+};
+struct TriHasher
+{
+  std::size_t operator()(const TriKey & t) const noexcept
+  {
+    std::size_t h = 1469598103934665603ull;
+    auto mix = [&](int k){
+        h ^= static_cast<std::size_t>(k) + 0x9e3779b97f4a7c15ull + (h << 6) + (h >> 2);
+      };
+    mix(t.a); mix(t.b); mix(t.c);
+    return h;
+  }
+};
+static inline TriKey make_tri(int i, int j, int k)
+{
+  int v[3] = {i, j, k};
+  std::sort(v, v + 3);
+  return {v[0], v[1], v[2]};
+}
+
+// PCA local para obtener plano tangente en v
+// Devuelve dos ejes ortogonales t1, t2 en el plano tangente.
+// Si falla PCA (muy pocos puntos), usa un par ortonormal arbitrario.
+inline void local_tangent_basis(
+  const std::vector<Eigen::Vector3f> & nbrs,
+  Eigen::Vector3f & t1, Eigen::Vector3f & t2)
+{
+  if (nbrs.size() < 3) {
+    // base por defecto (proyección estable)
+    t1 = Eigen::Vector3f::UnitX();
+    t2 = Eigen::Vector3f::UnitY();
+    return;
+  }
+
+  // Centra
+  Eigen::Vector3f mean = Eigen::Vector3f::Zero();
+  for (auto & p : nbrs) {
+    mean += p;
+  }
+  mean /= static_cast<float>(nbrs.size());
+
+  // Covarianza
+  Eigen::Matrix3f C = Eigen::Matrix3f::Zero();
+  for (auto & p : nbrs) {
+    Eigen::Vector3f d = p - mean;
+    C += d * d.transpose();
+  }
+  C /= static_cast<float>(nbrs.size());
+
+  // Autovectores
+  Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> es(C);
+  // Valores ascendentes: 0 -> menor (normal aproximada)
+  // Eigen::Vector3f e0 = es.eigenvectors().col(0); // normal aproximada
+  Eigen::Vector3f e1 = es.eigenvectors().col(1);
+  Eigen::Vector3f e2 = es.eigenvectors().col(2);
+
+  // Plano tangente: proyectaremos en {e1, e2}
+  // Asegura ortonormalidad y evita inversión esporádica
+  t1 = e1.normalized();
+  t2 = (e2 - e2.dot(t1) * t1).normalized();
+}
+
+inline void triangle_angles_deg(
+  const Eigen::Vector3f & A,
+  const Eigen::Vector3f & B,
+  const Eigen::Vector3f & C,
+  float & angA, float & angB, float & angC)
+{
+  // Lados opuestos a A, B, C
+  float a = (B - C).norm();
+  float b = (C - A).norm();
+  float c = (A - B).norm();
+
+  // Evitar divisiones por cero
+  const float eps = 1e-12f;
+  a = std::max(a, eps);
+  b = std::max(b, eps);
+  c = std::max(c, eps);
+
+  // Ley de cosenos con clamp numérico
+  auto angle_from = [](float opp, float x, float y) -> float {
+      float cosv = (x * x + y * y - opp * opp) / (2.0f * x * y);
+      cosv = std::min(1.0f, std::max(-1.0f, cosv));
+      return std::acos(cosv) * 180.0f / static_cast<float>(M_PI);
+    };
+
+  angA = angle_from(a, b, c);
+  angB = angle_from(b, c, a);
+  angC = angle_from(c, a, b);
+}
+
+// Ordena vecinos por ángulo en el plano tangente de v
+inline void sort_neighbors_angular(
+  const Eigen::Vector3f & vpos,
+  const std::vector<std::pair<int, Eigen::Vector3f>> & nbrs,  // (idx, pos)
+  std::vector<int> & out_ordered)
+{
+  std::vector<Eigen::Vector3f> pts;
+  pts.reserve(nbrs.size() + 1);
+  pts.push_back(vpos);
+  for (auto & it : nbrs) {
+    pts.push_back(it.second);
+  }
+
+  Eigen::Vector3f t1, t2;
+  local_tangent_basis(pts, t1, t2);
+
+  std::vector<std::pair<float, int>> ang_idx;
+  ang_idx.reserve(nbrs.size());
+  for (auto & it : nbrs) {
+    Eigen::Vector3f d = it.second - vpos;
+    float x = d.dot(t1);
+    float y = d.dot(t2);
+    float ang = std::atan2(y, x); // -pi..pi
+    ang_idx.emplace_back(ang, it.first);
+  }
+
+  std::sort(ang_idx.begin(), ang_idx.end(),
+    [](auto & a, auto & b){return a.first < b.first;});
+
+  out_ordered.clear();
+  out_ordered.reserve(ang_idx.size());
+  for (auto & ai : ang_idx) {
+    out_ordered.push_back(ai.second);
+  }
+}
+
+// Intenta crear un triángulo (i,j,k) bajo las restricciones
+inline bool try_add_triangle(
+  int i, int j, int k,
+  const pcl::PointCloud<pcl::PointXYZ> & cloud,
+  const BuildParams & P,
+  std::unordered_set<TriKey, TriHasher> & tri_set,
+  std::unordered_set<EdgeKey, EdgeHasher> & edge_set,
+  std::vector<Triangle> & tris)
+{
+  TriKey tk = make_tri(i, j, k);
+  if (tri_set.find(tk) != tri_set.end()) {return false;}
+
+  const auto & A = cloud[i];
+  const auto & B = cloud[j];
+  const auto & C = cloud[k];
+  if (!pcl::isFinite(A) || !pcl::isFinite(B) || !pcl::isFinite(C)) {return false;}
+
+  // Longitudes máximas de arista
+  auto dAB = dist3(A, B);
+  auto dBC = dist3(B, C);
+  auto dCA = dist3(C, A);
+  if (dAB > P.max_edge_len || dBC > P.max_edge_len || dCA > P.max_edge_len) {return false;}
+
+  Eigen::Vector3f a(A.x, A.y, A.z);
+  Eigen::Vector3f b(B.x, B.y, B.z);
+  Eigen::Vector3f c(C.x, C.y, C.z);
+
+  // Área mínima
+  if (tri_area(a, b, c) < P.min_area) {return false;}
+
+  // Pendiente máxima
+  float slope = tri_slope_deg(a, b, c);
+  if (slope > P.max_slope_deg) {return false;}
+
+  // Ángulo mínimo en los tres vértices
+  float angA, angB, angC;
+  triangle_angles_deg(a, b, c, angA, angB, angC);
+  if (angA < P.min_angle_deg || angB < P.min_angle_deg || angC < P.min_angle_deg) {
+    return false;
+  }
+
+  {
+    const Eigen::Vector3f up = Eigen::Vector3f::UnitZ();
+    Eigen::Vector3f n = (b - a).cross(c - a);
+    if (n.norm() < 1e-9f) {return false;}
+    if (n.dot(up) < 0.0f) {
+      std::swap(j, k);
+      // si más abajo usas b/c otra vez, re-asigna:
+      // b = Eigen::Vector3f(cloud[j].x, cloud[j].y, cloud[j].z);
+      // c = Eigen::Vector3f(cloud[k].x, cloud[k].y, cloud[k].z);
+    }
+  }
+
+  // Aceptar
+  tri_set.insert(tk);
+  edge_set.insert(make_edge(i, j));
+  edge_set.insert(make_edge(j, k));
+  edge_set.insert(make_edge(k, i));
+  tris.emplace_back(Triangle(i, j, k));
+  return true;
+}
+
+struct Voxel
+{
+  int x, y, z;
+  bool operator==(const Voxel & o) const noexcept
+  {
+    return x == o.x && y == o.y && z == o.z;
+  }
+};
+
+struct VoxelHash
+{
+  std::size_t operator()(const Voxel & v) const noexcept
+  {
+    // Hash simple y estable
+    std::size_t h = 1469598103934665603ull; // FNV-1a offset
+    auto mix = [&](int k) {
+        std::size_t x = static_cast<std::size_t>(k);
+        h ^= x + 0x9e3779b97f4a7c15ull + (h << 6) + (h >> 2);
+      };
+    mix(v.x); mix(v.y); mix(v.z);
+    return h;
+  }
+};
+
+struct VoxelAccum
+{
+  float sum_x = 0.0f;
+  float sum_y = 0.0f;
+  float sum_z = 0.0f;
+  int count = 0;
+};
+
+
+pcl::PointCloud<pcl::PointXYZ>
+downsample_voxelize_avgXYZ(
+  const pcl::PointCloud<pcl::PointXYZ> & input_points,
+  float resolution)
+{
+  pcl::PointCloud<pcl::PointXYZ> output;
+
+  std::unordered_map<Voxel, VoxelAccum, VoxelHash> voxels;
+  voxels.reserve(input_points.size() / 2); // estimación
+
+  // 1) Acumular todos los puntos por voxel
+  for (std::size_t i = 0; i < input_points.size(); ++i) {
+    const auto & pt = input_points[i];
+    if (!pcl::isFinite(pt)) {continue;}
+
+    int vx = static_cast<int>(std::floor(pt.x / resolution));
+    int vy = static_cast<int>(std::floor(pt.y / resolution));
+    int vz = static_cast<int>(std::floor(pt.z / resolution));
+
+    Voxel v{vx, vy, vz};
+    auto & acc = voxels[v];
+    acc.sum_x += pt.x;
+    acc.sum_y += pt.y;
+    acc.sum_z += pt.z;
+    acc.count += 1;
+  }
+
+  // 2) Generar un punto promedio por voxel
+  output.points.reserve(voxels.size());
+  for (const auto & kv : voxels) {
+    const VoxelAccum & acc = kv.second;
+    float cx = acc.sum_x / acc.count;
+    float cy = acc.sum_y / acc.count;
+    float cz = acc.sum_z / acc.count;
+    output.emplace_back(cx, cy, cz);
+  }
+
+  output.width = static_cast<uint32_t>(output.size());
+  output.height = 1;
+  output.is_dense = true;
+
+  return output;
+}
+
+
+std::vector<Triangle> grow_surface_from_seed(
+  const pcl::PointCloud<pcl::PointXYZ> & cloud,
+  int seed_idx,
+  const BuildParams & P)
+{
+  std::cerr << "1" << std::endl;
+  std::vector<Triangle> tris;
+  if (cloud.empty() || seed_idx < 0 || seed_idx >= static_cast<int>(cloud.size())) {
+    return tris;
+  }
+
+  pcl::KdTreeFLANN<pcl::PointXYZ> kdtree;
+  kdtree.setInputCloud(cloud.makeShared());
+
+  std::queue<int> frontier;
+  std::unordered_set<int> seen;
+  frontier.push(seed_idx);
+  seen.insert(seed_idx);
+
+  std::unordered_set<TriKey, TriHasher> tri_set;
+  std::unordered_set<EdgeKey, EdgeHasher> edge_set;
+
+  std::vector<int> nbr_indices;
+  std::vector<float> nbr_dists;
+
+  while (!frontier.empty()) {
+    int v = frontier.front(); frontier.pop();
+    const auto & V = cloud[v];
+
+    if (!pcl::isFinite(V)) {continue;}
+
+    // 1) Vecindad
+    nbr_indices.clear(); nbr_dists.clear();
+    int found = 0;
+    if (P.use_radius) {
+      found = kdtree.radiusSearch(V, P.neighbor_radius, nbr_indices, nbr_dists);
+    } else {
+      found = kdtree.nearestKSearch(V, P.k_neighbors, nbr_indices, nbr_dists);
+    }
+    if (found <= 1) {continue;} // sólo él mismo
+
+    // 2) Filtra por arista y descarta el propio v
+    std::vector<std::pair<int, Eigen::Vector3f>> candidates;
+    candidates.reserve(found);
+    for (int idx : nbr_indices) {
+      if (idx == v) {continue;}
+      const auto & Pn = cloud[idx];
+      if (!pcl::isFinite(Pn)) {continue;}
+      if (dist3(V, Pn) <= P.max_edge_len) {
+        candidates.emplace_back(idx, Eigen::Vector3f(Pn.x, Pn.y, Pn.z));
+      }
+    }
+    if (candidates.size() < 2) {continue;}
+
+    // 3) Orden angular en plano tangente local de v
+    Eigen::Vector3f vpos(V.x, V.y, V.z);
+    std::vector<int> ordered;
+    sort_neighbors_angular(vpos, candidates, ordered);
+
+    // 4) Intenta triángulos en abanico (pares consecutivos)
+    //    También puedes cerrar el abanico conectando último con primero si procede.
+    for (size_t t = 0; t + 1 < ordered.size(); ++t) {
+      // std::cerr << "t = " << t <<std::endl;
+      int i = v;
+      int j = ordered[t];
+      int k = ordered[t + 1];
+
+      if (try_add_triangle(i, j, k, cloud, P, tri_set, edge_set, tris)) {
+        if (!seen.count(j)) {frontier.push(j); seen.insert(j);}
+        if (!seen.count(k)) {frontier.push(k); seen.insert(k);}
+      }
+    }
+    // Cierre opcional del abanico (si quieres malla más densa):
+    int j0 = ordered.front(), k0 = ordered.back();
+    try_add_triangle(v, k0, j0, cloud, P, tri_set, edge_set, tris);
+  }
+
+  return tris;
+}
+
+navmap::NavMap from_pointcloud2(
+  const sensor_msgs::msg::PointCloud2 & pc2,
+  navmap_ros_interfaces::msg::NavMap & out_msg,
+  BuildParams params)
+{
+  pcl::PointCloud<pcl::PointXYZ> input_points;
+  pcl::fromROSMsg(pc2, input_points);
+
+  auto downsampled_points = downsample_voxelize_avgXYZ(input_points, params.resolution);
+
+  pcl::KdTreeFLANN<pcl::PointXYZ> kdtree;
+  kdtree.setInputCloud(downsampled_points.makeShared());
+
+  pcl::PointXYZ origin(params.seed.x(), params.seed.y(), params.seed.z());
+
+  std::vector<int> nbr_indices;
+  std::vector<float> nbr_dists;
+
+  nbr_indices.clear(); nbr_dists.clear();
+  bool found = kdtree.radiusSearch(origin, params.resolution, nbr_indices, nbr_dists);
+
+  if (!found) {
+    std::cerr << "Unable to find surface near seed" << std::endl;
+    return {};
+  }
+
+  int seed = nbr_indices[0];
+
+  auto triangles = grow_surface_from_seed(downsampled_points, seed, params);
+
+  navmap::NavMap navmap;
+  if (!navmap_ros::build_navmap_from_mesh(
+    downsampled_points, triangles, "map", out_msg, &navmap))
+  {
+    std::cerr << "Error building ::navmap::NavMap from mesh" << std::endl;
+    return {};
+  }
+
+  return navmap;
+}
+
 
 } // namespace navmap_ros

--- a/navmap_ros/src/navmap_ros/navmap_io.cpp
+++ b/navmap_ros/src/navmap_ros/navmap_io.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #include <fstream>

--- a/navmap_ros/src/slam_server_app.cpp
+++ b/navmap_ros/src/slam_server_app.cpp
@@ -1,0 +1,95 @@
+// Copyright 2025 Intelligent Robotics Lab
+//
+// This file is part of the project Easy Navigation (EasyNav in short)
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "navmap_core/NavMap.hpp"
+#include "navmap_ros/conversions.hpp"
+#include "navmap_ros/navmap_io.hpp"
+
+#include "nav_msgs/msg/occupancy_grid.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
+#include "std_srvs/srv/trigger.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/macros.hpp"
+
+class SLAMServerNode : public rclcpp::Node
+{
+public:
+  RCLCPP_SMART_PTR_DEFINITIONS(SLAMServerNode)
+
+  SLAMServerNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
+  : Node("slam_server_node", options)
+  {
+    navmap_pub_ = create_publisher<navmap_ros_interfaces::msg::NavMap>("navmap",
+      rclcpp::QoS(1).transient_local().reliable());
+
+    incoming_occ_map_sub_ = create_subscription<nav_msgs::msg::OccupancyGrid>(
+      "incoming_occ_map", rclcpp::QoS(1).transient_local().reliable(),
+      [this](nav_msgs::msg::OccupancyGrid::UniquePtr msg) {
+        RCLCPP_INFO(get_logger(), "Creating and publishing NavMap from OccupancyGrid");
+
+        navmap_ = navmap_ros::from_occupancy_grid(*msg);
+
+        navmap_msg_ = navmap_ros::to_msg(navmap_);
+        navmap_msg_.header.frame_id = "map";
+        navmap_msg_.header.stamp = now();
+        navmap_pub_->publish(navmap_msg_);
+      });
+
+    incoming_pc2_map_sub_ = create_subscription<sensor_msgs::msg::PointCloud2>(
+      "incoming_pc2_map", rclcpp::QoS(100),
+      [this](sensor_msgs::msg::PointCloud2::UniquePtr msg) {
+        RCLCPP_INFO(get_logger(), "Creating and publishing NavMap from PointCloud2");
+        navmap_ros::BuildParams params;
+        navmap_ = navmap_ros::from_pointcloud2(*msg, navmap_msg_, params);
+
+        navmap_msg_.header.frame_id = "map";
+        navmap_msg_.header.stamp = now();
+        navmap_pub_->publish(navmap_msg_);
+      });
+
+    savemap_srv_ = create_service<std_srvs::srv::Trigger>("savemap",
+        [this](
+          const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+          std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+        {
+          (void)request;
+          (void)response;
+          RCLCPP_INFO(get_logger(), "Saving NavMap from /tmp/map.navmap");
+
+          navmap_ros::io::save_to_file(navmap_, "/tmp/map.navmap");
+    });
+  }
+
+private:
+  navmap::NavMap navmap_;
+  navmap_ros_interfaces::msg::NavMap navmap_msg_;
+
+  rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr incoming_occ_map_sub_;
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr incoming_pc2_map_sub_;
+  rclcpp::Publisher<navmap_ros_interfaces::msg::NavMap>::SharedPtr navmap_pub_;
+
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr savemap_srv_;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+
+  auto slam_server_node = SLAMServerNode::make_shared();
+  rclcpp::spin(slam_server_node);
+
+  return 0;
+}

--- a/navmap_ros/tests/test_conversions.cpp
+++ b/navmap_ros/tests/test_conversions.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <gtest/gtest.h>
 #include <nav_msgs/msg/occupancy_grid.hpp>

--- a/navmap_ros/tests/test_navmap_io.cpp
+++ b/navmap_ros/tests/test_navmap_io.cpp
@@ -1,21 +1,17 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
 // This file is part of the project Easy Navigation (EasyNav in short)
-// licensed under the GNU General Public License v3.0.
-// See <http://www.gnu.org/licenses/> for details.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Easy Navigation program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <gtest/gtest.h>
 #include <rclcpp/serialization.hpp>

--- a/navmap_ros_interfaces/package.xml
+++ b/navmap_ros_interfaces/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.1</version>
   <description>ROS 2 interfaces for NavMap (messages for visualization and layers)</description>
   <maintainer email="fmrico@gmail.com">Francisco Martín Rico</maintainer>
-  <license>GPLv3</license>
+  <license>Apache License, Version 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/navmap_rviz_plugin/include/navmap_rviz_plugin/NavMapDisplay.hpp
+++ b/navmap_rviz_plugin/include/navmap_rviz_plugin/NavMapDisplay.hpp
@@ -1,7 +1,18 @@
 // Copyright 2025 Intelligent Robotics Lab
 //
-// This file is part of Easy Navigation (EasyNav) under GPLv3.
-// See <http://www.gnu.org/licenses/> for details.
+// This file is part of the project Easy Navigation (EasyNav in short)
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 
 #ifndef NAVMAP_RVIZ_PLUGIN__NAVMAP_DISPLAY_HPP_
 #define NAVMAP_RVIZ_PLUGIN__NAVMAP_DISPLAY_HPP_

--- a/navmap_rviz_plugin/package.xml
+++ b/navmap_rviz_plugin/package.xml
@@ -6,7 +6,8 @@
   <version>0.1.0</version>
   <description>RViz2 display plugin for NavMap surfaces and layers.</description>
   <maintainer email="fmrico@gmail.com">Francisco Martín Rico</maintainer>
-  <license>GPL-3.0-or-later</license>
+
+  <license>Apache License, Version 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/navmap_rviz_plugin/src/NavMapDisplay.cpp
+++ b/navmap_rviz_plugin/src/NavMapDisplay.cpp
@@ -1,5 +1,18 @@
-// Copyright 2025
-// GPLv3
+// Copyright 2025 Intelligent Robotics Lab
+//
+// This file is part of the project Easy Navigation (EasyNav in short)
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 
 #include "navmap_rviz_plugin/NavMapDisplay.hpp"
 

--- a/navmap_rviz_plugin/src/NavMapDisplay.cpp
+++ b/navmap_rviz_plugin/src/NavMapDisplay.cpp
@@ -186,8 +186,8 @@ void NavMapDisplay::reset()
   layer_update_count_ = 0;
   last_navmap_stamp_ = rclcpp::Time(0, 0, RCL_ROS_TIME);
   last_layer_stamp_ = rclcpp::Time(0, 0, RCL_ROS_TIME);
-  setStatus(rviz_common::properties::StatusProperty::Warn, "NavMap Topic", "waiting for messages…");
-  setStatus(rviz_common::properties::StatusProperty::Warn, "Layer Update", "waiting for updates…");
+  setStatus(rviz_common::properties::StatusProperty::Ok, "NavMap Topic", "waiting for messages…");
+  setStatus(rviz_common::properties::StatusProperty::Ok, "Layer Update", "waiting for updates…");
 
   destroyMesh_();
   updateNormals_();


### PR DESCRIPTION
Hi,

I have decided to move the code from the currently developing `easynav_navmap_stack` to this package to have the function `from_pointcloud2` with the asociated type `BuildParams`:
```
struct BuildParams
{
  Eigen::Vector3f seed = {0.0, 0.0, 0.0};
  float resolution = 1.0;
  float max_edge_len = 2.0;
  float max_slope_deg = 30.0f;   // maximum slope w.r.t. vertical
  float neighbor_radius = 2.0f;  // search radius
  int   k_neighbors = 20;        // k-NN alternative to radius
  float min_area = 1e-6f;        // minimum triangle area to avoid degenerates
  bool  use_radius = true;
  float min_angle_deg = 20.0f;   // minimum interior angle (deg) to avoid sliver triangles
};

navmap::NavMap from_pointcloud2(
  const sensor_msgs::msg::PointCloud2 & pc2,
  navmap_ros_interfaces::msg::NavMap & out_msg,
  BuildParams params);
```

I have also added an executable `slam_server_app` which is able to receive `nav_msgs::msg::OccupancyGrid` and `sensor_msgs::msg::PointCloud2` and publish the corresponding `navmap_ros_interfaces::msg::NavMap`. Usage, for example, as follows:

```
ros2 run navmap_ros slam_server_app --ros-args -r /incoming_pc2_map:=/map 
```

I hope it helps