### PR TITLE
Separate periodic CI from PR/push

### DIFF
--- a/.github/workflows/humble_cron.yaml
+++ b/.github/workflows/humble_cron.yaml
@@ -1,12 +1,8 @@
 name: humble
 
 on:
-  pull_request:
-    branches:
-      - humble
-  push:
-    branches:
-      - humble
+  schedule:
+      - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
@@ -27,6 +23,7 @@ jobs:
         with:
           package-name: navmap_core navmap_ros navmap_ros_interfaces navmap_rviz_plugin
           target-ros2-distro: humble
+          ref: humble
           colcon-defaults: |
             {
               "test": {

--- a/.github/workflows/jazzy.yaml
+++ b/.github/workflows/jazzy.yaml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - jazzy
-  schedule:
-      - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
@@ -29,7 +27,6 @@ jobs:
         with:
           package-name: navmap_core navmap_ros navmap_ros_interfaces navmap_rviz_plugin
           target-ros2-distro: jazzy
-          ref: jazzy
           colcon-defaults: |
             {
               "test": {

--- a/.github/workflows/jazzy_cron.yaml
+++ b/.github/workflows/jazzy_cron.yaml
@@ -1,32 +1,29 @@
-name: humble
+name: jazzy
 
 on:
-  pull_request:
-    branches:
-      - humble
-  push:
-    branches:
-      - humble
+  schedule:
+      - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: humble
+          ref: jazzy
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
         with:
-          required-ros-distributions: humble
+          required-ros-distributions: jazzy
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:
           package-name: navmap_core navmap_ros navmap_ros_interfaces navmap_rviz_plugin
-          target-ros2-distro: humble
+          target-ros2-distro: jazzy
+          ref: jazzy
           colcon-defaults: |
             {
               "test": {

--- a/.github/workflows/kilted.yaml
+++ b/.github/workflows/kilted.yaml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - kilted
-  schedule:
-      - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
@@ -29,7 +27,6 @@ jobs:
         with:
           package-name: navmap_core navmap_ros navmap_ros_interfaces navmap_rviz_plugin
           target-ros2-distro: kilted
-          ref: kilted
           colcon-defaults: |
             {
               "test": {

--- a/.github/workflows/kilted_cron.yaml
+++ b/.github/workflows/kilted_cron.yaml
@@ -1,32 +1,29 @@
-name: humble
+name: kilted
 
 on:
-  pull_request:
-    branches:
-      - humble
-  push:
-    branches:
-      - humble
+  schedule:
+      - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: humble
+          ref: kilted
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
         with:
-          required-ros-distributions: humble
+          required-ros-distributions: kilted
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:
           package-name: navmap_core navmap_ros navmap_ros_interfaces navmap_rviz_plugin
-          target-ros2-distro: humble
+          target-ros2-distro: kilted
+          ref: kilted
           colcon-defaults: |
             {
               "test": {

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - rolling
-  schedule:
-      - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
@@ -29,7 +27,6 @@ jobs:
         with:
           package-name: navmap_core navmap_ros navmap_ros_interfaces navmap_rviz_plugin
           target-ros2-distro: rolling
-          ref: rolling
           colcon-defaults: |
             {
               "test": {

--- a/.github/workflows/rolling_cron.yaml
+++ b/.github/workflows/rolling_cron.yaml
@@ -1,32 +1,29 @@
-name: humble
+name: rolling
 
 on:
-  pull_request:
-    branches:
-      - humble
-  push:
-    branches:
-      - humble
+  schedule:
+      - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: humble
+          ref: rolling
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
         with:
-          required-ros-distributions: humble
+          required-ros-distributions: rolling
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:
           package-name: navmap_core navmap_ros navmap_ros_interfaces navmap_rviz_plugin
-          target-ros2-distro: humble
+          target-ros2-distro: rolling
+          ref: rolling
           colcon-defaults: |
             {
               "test": {


### PR DESCRIPTION
This PR is related to https://github.com/EasyNavigation/EasyNavigation/pull/69, and separates periodic CI, which requires a `ref: <branch>` tag, from push/PR, which this tag mekes it fail