### PR TITLE
PCL private linkage: avoid Qt5/6 conflicts

### DIFF
--- a/.github/workflows/humble.yaml
+++ b/.github/workflows/humble.yaml
@@ -9,19 +9,15 @@ on:
       - humble
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-22.04]
-      fail-fast: false
+    runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:jammy
     steps:
       - uses: actions/checkout@v4
         with:
           ref: humble
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: humble
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:

--- a/.github/workflows/humble_cron.yaml
+++ b/.github/workflows/humble_cron.yaml
@@ -5,19 +5,15 @@ on:
       - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-22.04]
-      fail-fast: false
+    runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:jammy
     steps:
       - uses: actions/checkout@v4
         with:
           ref: humble
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: humble
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:

--- a/.github/workflows/jazzy.yaml
+++ b/.github/workflows/jazzy.yaml
@@ -9,19 +9,15 @@ on:
       - jazzy
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-      fail-fast: false
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v4
         with:
           ref: jazzy
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: jazzy
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:

--- a/.github/workflows/jazzy_cron.yaml
+++ b/.github/workflows/jazzy_cron.yaml
@@ -5,19 +5,15 @@ on:
       - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-      fail-fast: false
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v4
         with:
           ref: jazzy
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: jazzy
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:

--- a/.github/workflows/kilted.yaml
+++ b/.github/workflows/kilted.yaml
@@ -9,19 +9,15 @@ on:
       - kilted
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-      fail-fast: false
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v4
         with:
           ref: kilted
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: kilted
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:

--- a/.github/workflows/kilted_cron.yaml
+++ b/.github/workflows/kilted_cron.yaml
@@ -5,19 +5,15 @@ on:
       - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-      fail-fast: false
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v4
         with:
           ref: kilted
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: kilted
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -9,19 +9,15 @@ on:
       - rolling
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-      fail-fast: false
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v4
         with:
           ref: rolling
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: rolling
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:

--- a/.github/workflows/rolling_cron.yaml
+++ b/.github/workflows/rolling_cron.yaml
@@ -5,19 +5,15 @@ on:
       - cron: '0 0 * * 6'     
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-      fail-fast: false
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:noble
     steps:
       - uses: actions/checkout@v4
         with:
           ref: rolling
       - name: Setup ROS 2
         uses: ros-tooling/setup-ros@0.7.15
-        with:
-          required-ros-distributions: rolling
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.5
         with:

--- a/navmap_ros/CMakeLists.txt
+++ b/navmap_ros/CMakeLists.txt
@@ -28,16 +28,18 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:include>
   ${PCL_INCLUDE_DIRS}
 )
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  pcl_conversions::pcl_conversions
+  ${PCL_LIBRARIES}
+)
 target_link_libraries(${PROJECT_NAME} PUBLIC
   rclcpp::rclcpp
   navmap_core::navmap_core
-  pcl_conversions::pcl_conversions
   ${navmap_ros_interfaces_TARGETS}
   ${geometry_msgs_TARGETS}
   ${nav_msgs_TARGETS}
   ${sensor_msgs_TARGETS}
   ${std_srvs_TARGETS}
-  ${PCL_LIBRARIES}
 )
 add_executable(slam_server_app
   src/slam_server_app.cpp
@@ -76,6 +78,7 @@ ament_export_dependencies(
   rclcpp
   navmap_core
   navmap_ros_interfaces
+  nav_msgs
   geometry_msgs
   sensor_msgs
   std_srvs

--- a/navmap_rviz_plugin/CMakeLists.txt
+++ b/navmap_rviz_plugin/CMakeLists.txt
@@ -1,14 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(navmap_rviz_plugin)
 
-# 1) Qt y AUTOMOC
-find_package(Qt5 REQUIRED COMPONENTS Core Widgets)
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTORCC ON)
-set(CMAKE_AUTOUIC ON)
-
-# add_definitions(-DQT_NO_KEYWORDS)
-
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rviz_common REQUIRED)
@@ -23,12 +15,6 @@ find_package(navmap_core REQUIRED)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-qt5_wrap_cpp(NAVMAP_MOC_SRCS
-  include/navmap_rviz_plugin/NavMapDisplay.hpp
-  include/navmap_rviz_plugin/navmap_goal_tool.hpp
-  include/navmap_rviz_plugin/navmap_pose_tool.hpp
-)
-
 add_library(${PROJECT_NAME} SHARED
   src/navmap_rviz_plugin/NavMapDisplay.cpp
   src/navmap_rviz_plugin/navmap_goal_tool.cpp
@@ -36,7 +22,6 @@ add_library(${PROJECT_NAME} SHARED
   include/navmap_rviz_plugin/NavMapDisplay.hpp
   include/navmap_rviz_plugin/navmap_goal_tool.hpp
   include/navmap_rviz_plugin/navmap_pose_tool.hpp
-  ${NAVMAP_MOC_SRCS}
 )
 target_link_libraries(navmap_rviz_plugin PUBLIC
   ${navmap_ros_interfaces_TARGETS}
@@ -47,8 +32,6 @@ target_link_libraries(navmap_rviz_plugin PUBLIC
   rviz_common::rviz_common
   rviz_rendering::rviz_rendering
   rviz_default_plugins::rviz_default_plugins
-  Qt5::Core
-  Qt5::Widgets
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -89,7 +72,6 @@ ament_export_dependencies(
   rviz_common
   rviz_rendering
   rviz_default_plugins
-  Qt5
   navmap_ros_interfaces
   geometry_msgs
   std_msg

--- a/navmap_rviz_plugin/CMakeLists.txt
+++ b/navmap_rviz_plugin/CMakeLists.txt
@@ -1,11 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(navmap_rviz_plugin)
 
-set(CMAKE_AUTORCC ON)
-set(CMAKE_AUTOUIC ON)
-
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+find_package(Qt6 REQUIRED COMPONENTS Widgets)
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -18,28 +14,10 @@ find_package(navmap_ros_interfaces REQUIRED)
 find_package(navmap_ros REQUIRED)
 find_package(navmap_core REQUIRED)
 
-find_package(QT NAMES Qt6 REQUIRED COMPONENTS Widgets Core)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Core)
-
-set(QT_LIBRARIES
-  Qt${QT_VERSION_MAJOR}::Core
-  Qt${QT_VERSION_MAJOR}::Gui
+qt_wrap_cpp(NAVMAP_MOC_SRCS
+    include/navmap_rviz_plugin/NavMapDisplay.hpp
+    include/navmap_rviz_plugin/navmap_goal_tool.hpp
 )
-
-set(NAVMAP_MOC_SRCS
-  include/navmap_rviz_plugin/NavMapDisplay.hpp
-  include/navmap_rviz_plugin/navmap_goal_tool.hpp
-  include/navmap_rviz_plugin/navmap_pose_tool.hpp
-)
-
-if (${QT_VERSION_MAJOR} GREATER "5")
-  qt_standard_project_setup()
-  qt_wrap_cpp(NAVMAP_MOC_SRCS
-  include/navmap_rviz_plugin/NavMapDisplay.hpp
-  include/navmap_rviz_plugin/navmap_goal_tool.hpp
-  include/navmap_rviz_plugin/navmap_pose_tool.hpp
-)
-endif()
 
 add_library(${PROJECT_NAME} SHARED
   src/navmap_rviz_plugin/NavMapDisplay.cpp
@@ -49,9 +27,7 @@ add_library(${PROJECT_NAME} SHARED
 )
 target_link_libraries(navmap_rviz_plugin PUBLIC
   ${navmap_ros_interfaces_TARGETS}
-  ${QT_QTCORE_LIBRARY}
-  ${QT_QTGUI_LIBRARY}
-  Qt${QT_VERSION_MAJOR}::Widgets
+  Qt6::Widgets
   navmap_ros::navmap_ros
   navmap_core::navmap_core
   pluginlib::pluginlib

--- a/navmap_rviz_plugin/CMakeLists.txt
+++ b/navmap_rviz_plugin/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.10)
 project(navmap_rviz_plugin)
 
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rviz_common REQUIRED)
@@ -12,19 +18,40 @@ find_package(navmap_ros_interfaces REQUIRED)
 find_package(navmap_ros REQUIRED)
 find_package(navmap_core REQUIRED)
 
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+find_package(QT NAMES Qt6 REQUIRED COMPONENTS Widgets Core)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Core)
+
+set(QT_LIBRARIES
+  Qt${QT_VERSION_MAJOR}::Core
+  Qt${QT_VERSION_MAJOR}::Gui
+)
+
+set(NAVMAP_MOC_SRCS
+  include/navmap_rviz_plugin/NavMapDisplay.hpp
+  include/navmap_rviz_plugin/navmap_goal_tool.hpp
+  include/navmap_rviz_plugin/navmap_pose_tool.hpp
+)
+
+if (${QT_VERSION_MAJOR} GREATER "5")
+  qt_standard_project_setup()
+  qt_wrap_cpp(NAVMAP_MOC_SRCS
+  include/navmap_rviz_plugin/NavMapDisplay.hpp
+  include/navmap_rviz_plugin/navmap_goal_tool.hpp
+  include/navmap_rviz_plugin/navmap_pose_tool.hpp
+)
+endif()
 
 add_library(${PROJECT_NAME} SHARED
   src/navmap_rviz_plugin/NavMapDisplay.cpp
   src/navmap_rviz_plugin/navmap_goal_tool.cpp
   src/navmap_rviz_plugin/navmap_pose_tool.cpp
-  include/navmap_rviz_plugin/NavMapDisplay.hpp
-  include/navmap_rviz_plugin/navmap_goal_tool.hpp
-  include/navmap_rviz_plugin/navmap_pose_tool.hpp
+  ${NAVMAP_MOC_SRCS}
 )
 target_link_libraries(navmap_rviz_plugin PUBLIC
   ${navmap_ros_interfaces_TARGETS}
+  ${QT_QTCORE_LIBRARY}
+  ${QT_QTGUI_LIBRARY}
+  Qt${QT_VERSION_MAJOR}::Widgets
   navmap_ros::navmap_ros
   navmap_core::navmap_core
   pluginlib::pluginlib
@@ -67,6 +94,7 @@ endif()
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(
+  Qt6
   rclcpp
   pluginlib
   rviz_common


### PR DESCRIPTION
Hi!

RViz no longer supports Qt5, which caused a version conflict with PCL (linked to VTK9/Qt5) in navmap_ros.
Marking the PCL linkage as private stops Qt5 headers from propagating, so RViz plugins can use Qt6 (preventing compilation errors as #8).

Best,
Esther